### PR TITLE
fix: cv2.error: OpenCV(3.4.2) 'function not implemented' issue in conda environment files

### DIFF
--- a/conda-cpu.yml
+++ b/conda-cpu.yml
@@ -1,10 +1,11 @@
 name: tracker-cpu
-
+channels:
+  - conda-forge
 dependencies:
   - python==3.7
   - pip
   - matplotlib
-  - opencv
+  - opencv==4.1.0
   - pip:
     - tensorflow==2.0.1
     - lxml

--- a/conda-gpu.yml
+++ b/conda-gpu.yml
@@ -1,10 +1,11 @@
-name: tracker-gpu
-
+name: yolov3_deepsort
+channels:
+  - conda-forge
 dependencies:
   - python==3.7
   - pip
   - matplotlib
-  - opencv
+  - opencv==4.1.0
   - cudnn
   - cudatoolkit==10.1.243
   - pip:


### PR DESCRIPTION
Hi,

I experienced a dependency issue while running the `object_tracker.py`, the `cvShowImage` function seems to have an error in openCV 3.4.2

```
cv2.error: OpenCV(3.4.2) /tmp/build/80754af9/opencv-suite_1535558553474/work/modules/highgui/src/window.cpp:632: error: (-2:Unspecified error) The function is not implemented. Rebuild the library with Windows, GTK+ 2.x or Carbon support. If you are on Ubuntu or Debian, install libgtk2.0-dev and pkg-config, then re-run cmake or configure script in function 'cvShowImage'
```

I was running the code on Ubuntu 18.04 machine with Nvidia GPU

I fixed this by installing openCV 4.1.0:
```bash
conda remove opencv
conda install -c conda-forge opencv=4.1.0
```

Hence, I modified the `conda-cpu.yml` and the `conda-gpu.yml` files to use conda-forge channel with openCV 4.1.0 on the lists. 

Hope this will help the rest trying this code.


Best regards,
SS